### PR TITLE
Allow to configure rollbax to contact api server via proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,14 @@ For non-production environments error reporting can be either disabled completel
 config :rollbax, enabled: :log
 ```
 
+### Using a proxy to reach the Rollbar server
+
+For environments which requires a proxy to connect hosts outside of the network, the `:proxy` config entry can be added with a _ProxyUrl_ as it's defined by [hackney](https://github.com/benoitc/hackney#proxy-a-connection).
+
+```elixir
+config :rollbax, proxy: "https://my-secure-proxy:5001"
+```
+
 ## Contributing
 
 To run tests, run `$ mix test --no-start`. The `--no-start` bit is important so that tests don't fail (because of the `:rollbax` application being started without an `:access_token` specifically).

--- a/lib/rollbax.ex
+++ b/lib/rollbax.ex
@@ -93,7 +93,14 @@ defmodule Rollbax do
 
     config =
       env
-      |> Keyword.take([:enabled, :custom, :api_endpoint, :enable_crash_reports, :reporters])
+      |> Keyword.take([
+        :enabled,
+        :custom,
+        :api_endpoint,
+        :enable_crash_reports,
+        :reporters,
+        :proxy
+      ])
       |> put_if_present(:environment, env[:environment])
       |> put_if_present(:access_token, env[:access_token])
 

--- a/test/rollbax/client_via_proxy_test.exs
+++ b/test/rollbax/client_via_proxy_test.exs
@@ -5,88 +5,34 @@ defmodule Rollbax.ClientViaProxyTest do
 
   setup_all do
     {:ok, pid} =
-      Rollbax.Client.start_link(
-        api_endpoint: "http://localhost:4004",
-        access_token: "token1",
-        environment: "test",
-        enabled: true,
-        custom: %{qux: "custom"},
-        proxy: "http://localhost:14001"
+      start_rollbax_client(
+        "token1",
+        "test",
+        %{proxied: "yes"},
+        "http://localhost:5005",
+        "http://localhost:7004"
       )
 
     on_exit(fn ->
-      ref = Process.monitor(pid)
-
-      receive do
-        {:DOWN, ^ref, _, _, _} -> :ok
-      end
+      ensure_rollbax_client_down(pid)
     end)
   end
 
-  defmodule Proxy do
-    alias Plug.Conn
-    alias Plug.Adapters.Cowboy
-
-    import Conn
-
-    def start(pid) do
-      Cowboy.http(__MODULE__, [test: pid], port: 14001)
-    end
-
-    def stop() do
-      :timer.sleep(100)
-      Cowboy.shutdown(__MODULE__.HTTP)
-      :timer.sleep(100)
-    end
-
-    def init(opts) do
-      Keyword.fetch!(opts, :test)
-    end
-
-    def call(%Conn{method: "POST"} = conn, test) do
-      {:ok, body, conn} = read_body(conn)
-      :timer.sleep(30)
-      json_body = Jason.decode!(body)
-      send(test, {:api_request_via_proxy, Jason.encode!(Map.put(json_body, "proxied", "yes"))})
-
-      if get_in(json_body, ["data", "custom", "return_error?"]) do
-        send_resp(conn, 400, ~s({"err": 1, "message": "that was a bad request"}))
-      else
-        send_resp(conn, 200, "{}")
-      end
-    end
-
-    def call(conn, _test) do
-      send_resp(conn, 404, "Not Found")
-    end
-  end
-
   setup do
-    {:ok, _} = RollbarAPI.start(self())
+    {:ok, _} = RollbarAPI.start(self(), 7004)
     on_exit(&RollbarAPI.stop/0)
-    {:ok, _} = Proxy.start(self())
-    on_exit(&Proxy.stop/0)
   end
 
   describe "with proxy" do
-    test "Client don't try to contact the api server" do
-      body = %{"message" => %{"body" => "pass"}}
-      occurrence_data = %{"server" => %{"host" => "example.net"}}
-      :ok = Client.emit(:warn, System.system_time(:second), body, _custom = %{}, occurrence_data)
-
-      refute_received :api_request
-      assert_receive {:api_request_via_proxy, body}
-    end
-
     test "Client send message to proxy server" do
       body = %{"message" => %{"body" => "pass"}}
       occurrence_data = %{"server" => %{"host" => "example.net"}}
       :ok = Client.emit(:warn, System.system_time(:second), body, _custom = %{}, occurrence_data)
 
-      assert_receive {:api_request_via_proxy, body}
+      assert_receive {:api_request, body}
       json_body = Jason.decode!(body)
       assert json_body["data"]["server"] == %{"host" => "example.net"}
-      assert json_body["proxied"] == "yes"
+      assert json_body["data"]["custom"] == %{"proxied" => "yes"}
     end
   end
 end

--- a/test/rollbax/client_via_proxy_test.exs
+++ b/test/rollbax/client_via_proxy_test.exs
@@ -1,0 +1,92 @@
+defmodule Rollbax.ClientViaProxyTest do
+  use ExUnit.RollbaxCase
+
+  alias Rollbax.Client
+
+  setup_all do
+    {:ok, pid} =
+      Rollbax.Client.start_link(
+        api_endpoint: "http://localhost:4004",
+        access_token: "token1",
+        environment: "test",
+        enabled: true,
+        custom: %{qux: "custom"},
+        proxy: "http://localhost:14001"
+      )
+
+    on_exit(fn ->
+      ref = Process.monitor(pid)
+
+      receive do
+        {:DOWN, ^ref, _, _, _} -> :ok
+      end
+    end)
+  end
+
+  defmodule Proxy do
+    alias Plug.Conn
+    alias Plug.Adapters.Cowboy
+
+    import Conn
+
+    def start(pid) do
+      Cowboy.http(__MODULE__, [test: pid], port: 14001)
+    end
+
+    def stop() do
+      :timer.sleep(100)
+      Cowboy.shutdown(__MODULE__.HTTP)
+      :timer.sleep(100)
+    end
+
+    def init(opts) do
+      Keyword.fetch!(opts, :test)
+    end
+
+    def call(%Conn{method: "POST"} = conn, test) do
+      {:ok, body, conn} = read_body(conn)
+      :timer.sleep(30)
+      json_body = Jason.decode!(body)
+      send(test, {:api_request_via_proxy, Jason.encode!(Map.put(json_body, "proxied", "yes"))})
+
+      if get_in(json_body, ["data", "custom", "return_error?"]) do
+        send_resp(conn, 400, ~s({"err": 1, "message": "that was a bad request"}))
+      else
+        send_resp(conn, 200, "{}")
+      end
+    end
+
+    def call(conn, _test) do
+      send_resp(conn, 404, "Not Found")
+    end
+  end
+
+  setup do
+    {:ok, _} = RollbarAPI.start(self())
+    on_exit(&RollbarAPI.stop/0)
+    {:ok, _} = Proxy.start(self())
+    on_exit(&Proxy.stop/0)
+  end
+
+  describe "with proxy" do
+    test "Client don't try to contact the api server" do
+      body = %{"message" => %{"body" => "pass"}}
+      occurrence_data = %{"server" => %{"host" => "example.net"}}
+      :ok = Client.emit(:warn, System.system_time(:second), body, _custom = %{}, occurrence_data)
+
+      refute_received :api_request
+      assert_receive {:api_request_via_proxy, body}
+    end
+
+    test "Client send message to proxy server" do
+      body = %{"message" => %{"body" => "pass"}}
+      occurrence_data = %{"server" => %{"host" => "example.net"}}
+      :ok = Client.emit(:warn, System.system_time(:second), body, _custom = %{}, occurrence_data)
+
+      assert_receive {:api_request_via_proxy, body}
+      json_body = Jason.decode!(body)
+      assert json_body["data"]["server"] == %{"host" => "example.net"}
+      assert json_body["proxied"] == "yes"
+    end
+  end
+end

--- a/test/rollbax/client_via_proxy_test.exs
+++ b/test/rollbax/client_via_proxy_test.exs
@@ -24,7 +24,7 @@ defmodule Rollbax.ClientViaProxyTest do
   end
 
   describe "with proxy" do
-    test "Client send message to proxy server" do
+    test "client send message to proxy server" do
       body = %{"message" => %{"body" => "pass"}}
       occurrence_data = %{"server" => %{"host" => "example.net"}}
       :ok = Client.emit(:warn, System.system_time(:second), body, _custom = %{}, occurrence_data)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -11,13 +11,20 @@ defmodule ExUnit.RollbaxCase do
     end
   end
 
-  def start_rollbax_client(token, env, custom \\ %{}) do
+  def start_rollbax_client(
+        token,
+        env,
+        custom \\ %{},
+        api_endpoint \\ "http://localhost:4004",
+        proxy \\ nil
+      ) do
     Rollbax.Client.start_link(
-      api_endpoint: "http://localhost:4004",
+      api_endpoint: api_endpoint,
       access_token: token,
       environment: env,
       enabled: true,
-      custom: custom
+      custom: custom,
+      proxy: proxy
     )
   end
 
@@ -49,8 +56,8 @@ defmodule RollbarAPI do
 
   import Conn
 
-  def start(pid) do
-    Cowboy.http(__MODULE__, [test: pid], port: 4004)
+  def start(pid, port \\ 4004) do
+    Cowboy.http(__MODULE__, [test: pid], port: port)
   end
 
   def stop() do


### PR DESCRIPTION
## Why?

Because some security hardened production environments require to contact the "outside" internet through a proxy and hackney (the erlang http client used by rollbax) doesn't read the usual env vars used to config a proxy.

## How?

Adding an optional entry to `Rollbar.config` allowing the specification of an URL to be passed to hackney to force the use of a proxy.

## Caveats

- The testing changes seems very complicated but are fast enough
- hackney will ignore the `proxy` option in case the value is nil, which simplify a lot passing & using the config.

Kudos to @amuino for guiding me to this solution