### PR TITLE
Raise if the enabled config value is not valid

### DIFF
--- a/lib/rollbax.ex
+++ b/lib/rollbax.ex
@@ -71,7 +71,7 @@ defmodule Rollbax do
   def start(_type, _args) do
     config = init_config()
 
-    unless Enum.member?([true, false, :log, nil], config[:enabled]) do
+    unless config[:enabled] in [true, false, :log] do
       raise ArgumentError, ":enabled may be only true, false, or :log"
     end
 

--- a/lib/rollbax.ex
+++ b/lib/rollbax.ex
@@ -71,6 +71,10 @@ defmodule Rollbax do
   def start(_type, _args) do
     config = init_config()
 
+    unless Enum.member?([true, false, :log, nil], config[:enabled]) do
+      raise ArgumentError, ":enabled may be only true, false, or :log"
+    end
+
     if config[:enabled] == true and is_nil(config[:access_token]) do
       raise ArgumentError, ":access_token is required when :enabled is true"
     end

--- a/test/rollbax_test.exs
+++ b/test/rollbax_test.exs
@@ -137,4 +137,29 @@ defmodule RollbaxTest do
              }
            } = assert_performed_request()
   end
+
+  describe "start/2" do
+    setup do
+      on_exit(fn ->
+        Application.delete_env(:rollbax, :enabled)
+      end)
+    end
+
+    test "when :enabled config value is invalid, it raises" do
+      Application.put_env(:rollbax, :enabled, "invalid_enabled_config_value")
+
+      assert_raise ArgumentError, ":enabled may be only true, false, or :log", fn ->
+        Rollbax.start(nil, nil)
+      end
+    end
+
+    test "when :enabled config value is true but :access_token is nil, it raises" do
+      Application.put_env(:rollbax, :enabled, true)
+      Application.delete_env(:rollbax, :access_token)
+
+      assert_raise ArgumentError, ":access_token is required when :enabled is true", fn ->
+        Rollbax.start(nil, nil)
+      end
+    end
+  end
 end


### PR DESCRIPTION
closes #106 

This raises if the config value for `:enabled` is not in `true|false|:log|nil`. This is just a rough sketch that I clean up if you approve @whatyouhide . I also added a test for the change introduced in #76 .

If you approve of this approach, I'll also update the README and perhaps refactor just a touch.