### PR TITLE
Fix old child spec warning

### DIFF
--- a/lib/rollbax.ex
+++ b/lib/rollbax.ex
@@ -90,7 +90,7 @@ defmodule Rollbax do
     end
 
     children = [
-      Supervisor.Spec.worker(Rollbax.Client, [config])
+      {Rollbax.Client, [config]}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)


### PR DESCRIPTION
Changes the syntax to define children to remove a compilation warning in Elixir 1.11