### PR TITLE
Fix bug with children definition

### DIFF
--- a/lib/rollbax.ex
+++ b/lib/rollbax.ex
@@ -90,7 +90,7 @@ defmodule Rollbax do
     end
 
     children = [
-      {Rollbax.Client, [config]}
+      {Rollbax.Client, config}
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one)


### PR DESCRIPTION
`init_config` already returns a  list so we end up passing a list within a
list to the `start_link` function of `Rollbax.Client`. This then causes an
error during startup:

```
** (Mix) Could not start application rollbax: Rollbax.start(:normal, []) returned an error: shutdown: failed to start child: Rollbax.Client
    ** (EXIT) an exception was raised:
        ** (FunctionClauseError) no function clause matching in Rollbax.Item.draft/3
            (rollbax 0.11.0) lib/rollbax/item.ex:9: Rollbax.Item.draft(nil, nil, nil)
            (rollbax 0.11.0) lib/rollbax/client.ex:30: Rollbax.Client.start_link/1
            (stdlib 3.12.1) supervisor.erl:379: :supervisor.do_start_child_i/3
            (stdlib 3.12.1) supervisor.erl:365: :supervisor.do_start_child/2
            (stdlib 3.12.1) supervisor.erl:349: anonymous fn/3 in :supervisor.start_children/2
            (stdlib 3.12.1) supervisor.erl:1157: :supervisor.children_map/4
            (stdlib 3.12.1) supervisor.erl:315: :supervisor.init_children/2
            (stdlib 3.12.1) gen_server.erl:374: :gen_server.init_it/2
            (stdlib 3.12.1) gen_server.erl:342: :gen_server.init_it/6
            (stdlib 3.12.1) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
```