### PR TITLE
Support Elixir 1.10 and later

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
             elixir: 1.5
           - otp: 21.3
             elixir: 1.8
+          - otp: 21.3
+            elixir: 1.10
+          - otp: 24
+            elixir: 1.13
 
     env:
       MIX_ENV: test

--- a/lib/rollbax/reporter/standard.ex
+++ b/lib/rollbax/reporter/standard.ex
@@ -114,8 +114,15 @@ defmodule Rollbax.Reporter.Standard do
         {:exit, reason, stacktrace} when is_atom(reason) ->
           {inspect(reason), inspect(reason), stacktrace, ""}
 
-        {_, info, stacktrace} when is_tuple(info) ->
-          case elem(info, 0) do
+        {_, info, stacktrace} ->
+          info =
+            if is_tuple(info) do
+              elem(info, 0)
+            else
+              info
+            end
+
+          case info do
             %class{message: message} ->
               {inspect(class), message, stacktrace, inspect(info)}
 

--- a/test/rollbax/logger_test.exs
+++ b/test/rollbax/logger_test.exs
@@ -32,8 +32,9 @@ defmodule Rollbax.LoggerTest do
 
       def init(args), do: {:ok, args}
 
-      def handle_cast(:raise_elixir, _state) do
-        Map.fetch!(Map.new(), :nonexistent_key)
+      def handle_cast(:raise_elixir, state) do
+        :ok = Map.fetch!(Map.new(), :nonexistent_key)
+        {:noreply, state}
       end
     end
 
@@ -236,7 +237,7 @@ defmodule Rollbax.LoggerTest do
       data = assert_performed_request()["data"]
 
       assert data["body"]["trace"]["exception"] == %{
-               "class" => "Task terminating (RuntimeError)",
+               "class" => "Crash report (RuntimeError)",
                "message" => "oops"
              }
 
@@ -246,7 +247,7 @@ defmodule Rollbax.LoggerTest do
                ~r[anonymous fn/0 in Rollbax.LoggerTest.(\")?test task with anonymous function raising an error(\")?/1]
 
       assert data["custom"]["name"] == inspect(task)
-      assert data["custom"]["function"] =~ ~r/\A#Function<.* in Rollbax\.LoggerTest/
+      assert data["custom"]["function"] =~ ~r/Rollbax\.LoggerTest/
       assert data["custom"]["arguments"] == "[]"
     end)
   end
@@ -262,7 +263,7 @@ defmodule Rollbax.LoggerTest do
       data = assert_performed_request()["data"]
 
       assert data["body"]["trace"]["exception"] == %{
-               "class" => "Task terminating (RuntimeError)",
+               "class" => "Crash report (RuntimeError)",
                "message" => "my message"
              }
 
@@ -272,8 +273,9 @@ defmodule Rollbax.LoggerTest do
       assert data["custom"] == %{
                "name" => inspect(task),
                "function" => "&MyModule.raise_error/1",
-               "arguments" => ~s(["my message"]),
-               "started_from" => inspect(self())
+               "arguments" => "[:Argument__1]",
+               "started_from" => inspect(self()),
+               "crash_report" => ""
              }
     end)
   after

--- a/test/rollbax/logger_test.exs
+++ b/test/rollbax/logger_test.exs
@@ -282,6 +282,19 @@ defmodule Rollbax.LoggerTest do
     purge_module(MyModule)
   end
 
+  test "task with undefined mfa" do
+    defmodule Test.UndefinedMFA do
+      def func(_arg), do: nil
+    end
+
+    capture_log(fn ->
+      {:ok, task} = Task.start(Test.UndefinedMFA, :func, [])
+      data = assert_performed_request()["data"]
+    end)
+  after
+    purge_module(Test.UndefinedMFA)
+  end
+
   if List.to_integer(:erlang.system_info(:otp_release)) < 19 do
     test "gen_fsm terminating" do
       defmodule Elixir.MyGenFsm do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -18,13 +18,16 @@ defmodule ExUnit.RollbaxCase do
         api_endpoint \\ "http://localhost:4004",
         proxy \\ nil
       ) do
-    Rollbax.Client.start_link(
-      api_endpoint: api_endpoint,
-      access_token: token,
-      environment: env,
-      enabled: true,
-      custom: custom,
-      proxy: proxy
+    start_supervised(
+      {Rollbax.Client,
+       [
+         api_endpoint: api_endpoint,
+         access_token: token,
+         environment: env,
+         enabled: true,
+         custom: custom,
+         proxy: proxy
+       ]}
     )
   end
 


### PR DESCRIPTION
Copy of https://github.com/ForzaElixir/rollbax/pull/118 with some additional improvements (and based on current `master`).
Implementation can be improved, and because of https://github.com/ForzaElixir/rollbax/pull/123/commits/0e5a30daf9dfca91813168edc6f01c248d7ab5c4 I wonder if there are more cases that are currently silently unhandled.

Additionally I'm not even sure I understand why we need to do this, and if we do need to translate OTP crash reports, maybe we could leverage `Logger.Translator`

Draft because this currently breaks for < 1.10 and I don't think the implementation is good enough yet.